### PR TITLE
Add MIT license and clean up imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENT Instructions for LLM Circuits Visualizer
+
+This repository contains a Next.js 15 web application that visualizes neuron activations in a large language model. The application resides in `llm-circuits-app/` and is deployed to Cloudflare using the `open-next` stack. The root of the repo also holds a number of markdown documents that outline the design and research behind the project.
+
+## Repository layout
+
+- `README.md` – project overview and feature list.
+- `architecture.md` – describes planned architecture and TypeScript interfaces for neurons, tokens and connections.
+- `research_notes.md` – collection of mechanistic interpretability notes.
+- `todo.md` – task list for the project.
+- `wireframes.md` – early design sketches.
+- `LICENSE` – MIT license for the project.
+- `llm-circuits-app/` – Next.js application source code.
+
+### Inside `llm-circuits-app`
+
+- `package.json` – configures the Next.js project and declares dependencies. Scripts include:
+  - `dev` – start the development server.
+  - `build` – build the production bundle.
+  - `lint` – run `next lint`.
+  - `build:worker` – build Cloudflare worker using `@opennextjs/cloudflare`.
+  - `preview` – build and run locally using Cloudflare's Wrangler.
+- `open-next.config.ts` and `wrangler.toml` – Cloudflare deployment settings.
+- `tailwind.config.ts` and `src/app/globals.css` – Tailwind CSS configuration.
+- `src/` – application source:
+  - `app/` – Next.js entry points and layout. `page.tsx` is the main UI where prompts are submitted and visualizations displayed.
+  - `components/visualization/` – React components for rendering neurons, tokens and interactive dialogs using React Three Fiber and Radix UI primitives.
+  - `components/ui/` – shared UI components based on Radix UI.
+  - `hooks/` – React hooks such as `useOpenAI` which handles prompt processing and neuron selection.
+  - `lib/openai.ts` – wrapper around the OpenAI API. Provides `OpenAIClient`, mock data generation utilities and a helper `getOpenAIClient` for environments that already have an API key configured.
+  - `migrations/` – example SQL for a Cloudflare D1 database (currently unused).
+
+## Notes for Future Agents
+
+1. **Programming language**: TypeScript/React with Next.js App Router.
+2. **Data**: Real neuron activations are not fetched. If no API key is provided, mock data is generated in `openai.ts`.
+3. **Build and lint**: Run `npm run lint` in `llm-circuits-app/`. This may fail without dependencies installed. Use `pnpm` if available.
+4. **Testing**: There are currently no automated tests.
+5. **License**: MIT license in `LICENSE` and `package.json`.
+6. **Important file**: `src/app/page.tsx` is the entry point and orchestrates OpenAI interactions and 3D visualizations.
+
+When adding new files or modifying code, please keep the structure organized under `llm-circuits-app/src`. Update documentation when necessary and ensure linting succeeds if dependencies are installed.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 The LLM Circuits Visualizer Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/llm-circuits-app/package.json
+++ b/llm-circuits-app/package.json
@@ -86,5 +86,6 @@
     "typescript": "^5",
     "wrangler": "^3.102.0"
   },
-  "packageManager": "pnpm@10.0.0-rc.2+sha512.b6e59b96f90ca92449ac2f6dca9b430880448fc97d21f0fa9200e3d5ddb5289ad535255400554f7f3486e2d60058492161aaa9b58828e81f50c096718be9d156"
+  "packageManager": "pnpm@10.0.0-rc.2+sha512.b6e59b96f90ca92449ac2f6dca9b430880448fc97d21f0fa9200e3d5ddb5289ad535255400554f7f3486e2d60058492161aaa9b58828e81f50c096718be9d156",
+  "license": "MIT"
 }

--- a/llm-circuits-app/src/app/page.tsx
+++ b/llm-circuits-app/src/app/page.tsx
@@ -5,7 +5,7 @@ import { NeuronHistoryModal, TokenComparisonModal } from '@/components/visualiza
 import NeuronModel from '@/components/visualization/NeuronModel';
 import TokenExplorer from '@/components/visualization/TokenExplorer';
 import NeuronInspector from '@/components/visualization/NeuronInspector';
-import { initializeOpenAIClient, getOpenAIClient } from '@/lib/openai';
+import { initializeOpenAIClient } from '@/lib/openai';
 import { useOpenAI } from '@/hooks/useOpenAI';
 
 // Enhanced version of the page component with interactive features


### PR DESCRIPTION
## Summary
- add a standard MIT LICENSE file
- remove an unused `getOpenAIClient` import
- mark package as MIT licensed
- document repository details for future agents in `AGENTS.md`

## Testing
- `npm run lint` *(fails: next not found)*